### PR TITLE
Add unicode_pair parameter.

### DIFF
--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -43,7 +43,7 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, unicode_pairs=None):
     new = new.lower() if lower else new
 
     if isinstance(unicode_pairs, dict):
-        for char in unicode_pairs:
-            new = new.replace(char, unicode_pairs[char])
+        for char, new_char in unicode_pairs.iteritems():
+            new = new.replace(char, new_char)
 
     return new

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -43,7 +43,7 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, unicode_pairs=None):
     new = new.lower() if lower else new
 
     if isinstance(unicode_pairs, dict):
-        for char, new_char in unicode_pairs.iteritems():
+        for char, new_char in unicode_pairs.items():
             new = new.replace(char, new_char)
 
     return new

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -26,7 +26,7 @@ def smart_text(s, encoding='utf-8', errors='strict'):
 SLUG_OK = '-_~'
 
 
-def slugify(s, ok=SLUG_OK, lower=True, spaces=False):
+def slugify(s, ok=SLUG_OK, lower=True, spaces=False, unicode_pairs=None):
     # L and N signify letter/number.
     # http://www.unicode.org/reports/tr44/tr44-4.html#GC_Values_Table
     rv = []
@@ -39,4 +39,9 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False):
     new = ''.join(rv).strip()
     if not spaces:
         new = re.sub('[-\s]+', '-', new)
+
+    if unicode_pairs and isinstance(unicode_pairs, dict):
+        for char in unicode_pairs:
+            new = new.replace(char, unicode_pairs[char])
+
     return new.lower() if lower else new

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -42,7 +42,7 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, unicode_pairs=None):
 
     new = new.lower() if lower else new
 
-    if unicode_pairs and isinstance(unicode_pairs, dict):
+    if isinstance(unicode_pairs, dict):
         for char in unicode_pairs:
             new = new.replace(char, unicode_pairs[char])
 

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -40,8 +40,10 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, unicode_pairs=None):
     if not spaces:
         new = re.sub('[-\s]+', '-', new)
 
+    new = new.lower() if lower else new
+
     if unicode_pairs and isinstance(unicode_pairs, dict):
         for char in unicode_pairs:
             new = new.replace(char, unicode_pairs[char])
 
-    return new.lower() if lower else new
+    return new

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -1,99 +1,92 @@
-    # -*- coding: utf-8 -*-
-    import six
-    import unittest
-    from nose.tools import eq_
+# -*- coding: utf-8 -*-
+import six
+import unittest
+from nose.tools import eq_
 
-    from slugify import slugify, smart_text
-
-
-    u = u'Ελληνικά'
+from slugify import slugify, smart_text
 
 
-    def test_slugify():
-        x = '-'.join([u, u])
-        y = ' - '.join([u, u])
-        unicode_pair = {u'\u20ac': 'E', u'\xe9': 'e'}
+u = u'Ελληνικά'
 
-        def check(x, y):
-            eq_(slugify(x), y)
 
-        def check_unicode_pair(x, y):
-            eq_(slugify(x, unicode_pair=unicode_pair), y)
+def test_slugify():
+    x = '-'.join([u, u])
+    y = ' - '.join([u, u])
+    unicode_pairs = {u'\u20ac': 'E', u'\xe9': 'e'}
 
-        s = [('xx x  - "#$@ x', 'xx-x-x'),
-             (u'Bän...g (bang)', u'bäng-bang'),
-             (u, u.lower()),
-             (x, x.lower()),
-             (y, x.lower()),
-             ('    a ', 'a'),
-             ('tags/', 'tags'),
-             ('holy_wars', 'holy_wars'),
-             # Make sure we get a consistent result with decomposed chars:
-             (u'el ni\N{LATIN SMALL LETTER N WITH TILDE}o', u'el-ni\xf1o'),
-             (u'el nin\N{COMBINING TILDE}o', u'el-ni\xf1o'),
-             # Ensure we normalize appearance-only glyphs into their compatibility
-             # forms:
-             (u'\N{LATIN SMALL LIGATURE FI}lms', u'films'),
-             # I don't really care what slugify returns.  Just don't crash.
-             (u'x𘍿', u'x'),
-             (u'ϧ΃𘒬𘓣',  u'\u03e7'),
-             (u'¿x', u'x'),
-            ]
+    def check(x, y):
+        eq_(slugify(x), y)
 
-        s_unicode_pair = [(u'This is curreny Euro (\u20ac)', u'This is curreny Euro (E)'),
-                          (u'This is e with a trail: \xe9', u'This is e with a trail: e')]
+    def check_unicode_pair(x, y):
+        eq_(slugify(x, unicode_pairs=unicode_pairs), y)
 
-        for val, expected in s:
-            yield check, val, expected
+    s = [('xx x  - "#$@ x', 'xx-x-x'),
+         (u'Bän...g (bang)', u'bäng-bang'),
+         (u, u.lower()),
+         (x, x.lower()),
+         (y, x.lower()),
+         ('    a ', 'a'),
+         ('tags/', 'tags'),
+         ('holy_wars', 'holy_wars'),
+         # Make sure we get a consistent result with decomposed chars:
+         (u'el ni\N{LATIN SMALL LETTER N WITH TILDE}o', u'el-ni\xf1o'),
+         (u'el nin\N{COMBINING TILDE}o', u'el-ni\xf1o'),
+         # Ensure we normalize appearance-only glyphs into their compatibility
+         # forms:
+         (u'\N{LATIN SMALL LIGATURE FI}lms', u'films'),
+         # I don't really care what slugify returns.  Just don't crash.
+         (u'x𘍿', u'x'),
+         (u'ϧ΃𘒬𘓣',  u'\u03e7'),
+         (u'¿x', u'x'),
+        ]
 
-        for val, expected in s_unicode_pair:
+    s_unicode_pair = [(u'This is curreny Euro (\u20ac)', u'This is curreny Euro (E)'),
+                      (u'This is e with a trail: \xe9', u'This is e with a trail: e')]
+
+    for val, expected in s:
+        yield check, val, expected
+
+    for val, expected in s_unicode_pair:
         yield check_unicode_pair, val, expected
 
-    class SmartTextTestCase(unittest.TestCase):
+class SmartTextTestCase(unittest.TestCase):
 
-        def test_smart_text_raises_an_error(self):
-            """Check that broken __unicode__/__str__ actually raises an error."""
+    def test_smart_text_raises_an_error(self):
+        """Check that broken __unicode__/__str__ actually raises an error."""
 
-            class MyString(object):
+        class MyString(object):
+            def __str__(self):
+                return b'\xc3\xb6\xc3\xa4\xc3\xbc'
+
+            __unicode__ = __str__
+
+        # str(s) raises a TypeError on python 3 if
+        # the result is not a text type.
+
+        # python 2 fails when it tries converting from
+        # str to unicode (via ASCII).
+        exception = TypeError if six.PY3 else UnicodeError
+        self.assertRaises(exception, smart_text, MyString())
+
+    def test_smart_text_works_for_data_model_methods(self):
+        """Should identify """
+        class TestClass:
+            if six.PY3:
                 def __str__(self):
-                    return b'\xc3\xb6\xc3\xa4\xc3\xbc'
+                    return 'ŠĐĆŽćžšđ'
 
-                __unicode__ = __str__
+                def __bytes__(self):
+                    return b'Foo'
+            else:
+                def __str__(self):
+                    return b'Foo'
 
-            # str(s) raises a TypeError on python 3 if
-            # the result is not a text type.
+                def __unicode__(self):
+                    return '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111'
 
-            # python 2 fails when it tries converting from
-            # str to unicode (via ASCII).
-            exception = TypeError if six.PY3 else UnicodeError
-            self.assertRaises(exception, smart_text, MyString())
-
-        def test_smart_text_works_for_data_model_methods(self):
-            """Should identify """
-            class TestClass:
-                if six.PY3:
-                    def __str__(self):
-                        return 'ŠĐĆŽćžšđ'
-
-                    def __bytes__(self):
-                        return b'Foo'
-                else:
-                    def __str__(self):
-                        return b'Foo'
-
-                    def __unicode__(self):
-                        return '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111'
-
-            self.assertEqual(smart_text(TestClass()),
-                             '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111')
-            self.assertEqual(smart_text(1), '1')
-            self.assertEqual(smart_text('foo'), 'foo')
-            self.assertEqual(smart_text(u), u)
-
-
-    class AdditionalParameterTestCase(unittest.TestCase):
-
-        def test_new_parameter_unicode_pair(self):
-            """  Check is unicode_pair parameter is working well. """
-
+        self.assertEqual(smart_text(TestClass()),
+                         '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111')
+        self.assertEqual(smart_text(1), '1')
+        self.assertEqual(smart_text('foo'), 'foo')
+        self.assertEqual(smart_text(u), u)
 

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -1,81 +1,99 @@
-# -*- coding: utf-8 -*-
-import six
-import unittest
-from nose.tools import eq_
+    # -*- coding: utf-8 -*-
+    import six
+    import unittest
+    from nose.tools import eq_
 
-from slugify import slugify, smart_text
-
-
-u = u'Ελληνικά'
+    from slugify import slugify, smart_text
 
 
-def test_slugify():
-    x = '-'.join([u, u])
-    y = ' - '.join([u, u])
-
-    def check(x, y):
-        eq_(slugify(x), y)
-
-    s = [('xx x  - "#$@ x', 'xx-x-x'),
-         (u'Bän...g (bang)', u'bäng-bang'),
-         (u, u.lower()),
-         (x, x.lower()),
-         (y, x.lower()),
-         ('    a ', 'a'),
-         ('tags/', 'tags'),
-         ('holy_wars', 'holy_wars'),
-         # Make sure we get a consistent result with decomposed chars:
-         (u'el ni\N{LATIN SMALL LETTER N WITH TILDE}o', u'el-ni\xf1o'),
-         (u'el nin\N{COMBINING TILDE}o', u'el-ni\xf1o'),
-         # Ensure we normalize appearance-only glyphs into their compatibility
-         # forms:
-         (u'\N{LATIN SMALL LIGATURE FI}lms', u'films'),
-         # I don't really care what slugify returns.  Just don't crash.
-         (u'x𘍿', u'x'),
-         (u'ϧ΃𘒬𘓣',  u'\u03e7'),
-         (u'¿x', u'x')]
-
-    for val, expected in s:
-        yield check, val, expected
+    u = u'Ελληνικά'
 
 
-class SmartTextTestCase(unittest.TestCase):
+    def test_slugify():
+        x = '-'.join([u, u])
+        y = ' - '.join([u, u])
+        unicode_pair = {u'\u20ac': 'E', u'\xe9': 'e'}
 
-    def test_smart_text_raises_an_error(self):
-        """Check that broken __unicode__/__str__ actually raises an error."""
+        def check(x, y):
+            eq_(slugify(x), y)
 
-        class MyString(object):
-            def __str__(self):
-                return b'\xc3\xb6\xc3\xa4\xc3\xbc'
+        def check_unicode_pair(x, y):
+            eq_(slugify(x, unicode_pair=unicode_pair), y)
 
-            __unicode__ = __str__
+        s = [('xx x  - "#$@ x', 'xx-x-x'),
+             (u'Bän...g (bang)', u'bäng-bang'),
+             (u, u.lower()),
+             (x, x.lower()),
+             (y, x.lower()),
+             ('    a ', 'a'),
+             ('tags/', 'tags'),
+             ('holy_wars', 'holy_wars'),
+             # Make sure we get a consistent result with decomposed chars:
+             (u'el ni\N{LATIN SMALL LETTER N WITH TILDE}o', u'el-ni\xf1o'),
+             (u'el nin\N{COMBINING TILDE}o', u'el-ni\xf1o'),
+             # Ensure we normalize appearance-only glyphs into their compatibility
+             # forms:
+             (u'\N{LATIN SMALL LIGATURE FI}lms', u'films'),
+             # I don't really care what slugify returns.  Just don't crash.
+             (u'x𘍿', u'x'),
+             (u'ϧ΃𘒬𘓣',  u'\u03e7'),
+             (u'¿x', u'x'),
+            ]
 
-        # str(s) raises a TypeError on python 3 if
-        # the result is not a text type.
+        s_unicode_pair = [(u'This is curreny Euro (\u20ac)', u'This is curreny Euro (E)'),
+                          (u'This is e with a trail: \xe9', u'This is e with a trail: e')]
 
-        # python 2 fails when it tries converting from
-        # str to unicode (via ASCII).
-        exception = TypeError if six.PY3 else UnicodeError
-        self.assertRaises(exception, smart_text, MyString())
+        for val, expected in s:
+            yield check, val, expected
 
-    def test_smart_text_works_for_data_model_methods(self):
-        """Should identify """
-        class TestClass:
-            if six.PY3:
+        for val, expected in s_unicode_pair:
+        yield check_unicode_pair, val, expected
+
+    class SmartTextTestCase(unittest.TestCase):
+
+        def test_smart_text_raises_an_error(self):
+            """Check that broken __unicode__/__str__ actually raises an error."""
+
+            class MyString(object):
                 def __str__(self):
-                    return 'ŠĐĆŽćžšđ'
+                    return b'\xc3\xb6\xc3\xa4\xc3\xbc'
 
-                def __bytes__(self):
-                    return b'Foo'
-            else:
-                def __str__(self):
-                    return b'Foo'
+                __unicode__ = __str__
 
-                def __unicode__(self):
-                    return '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111'
+            # str(s) raises a TypeError on python 3 if
+            # the result is not a text type.
 
-        self.assertEqual(smart_text(TestClass()),
-                         '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111')
-        self.assertEqual(smart_text(1), '1')
-        self.assertEqual(smart_text('foo'), 'foo')
-        self.assertEqual(smart_text(u), u)
+            # python 2 fails when it tries converting from
+            # str to unicode (via ASCII).
+            exception = TypeError if six.PY3 else UnicodeError
+            self.assertRaises(exception, smart_text, MyString())
+
+        def test_smart_text_works_for_data_model_methods(self):
+            """Should identify """
+            class TestClass:
+                if six.PY3:
+                    def __str__(self):
+                        return 'ŠĐĆŽćžšđ'
+
+                    def __bytes__(self):
+                        return b'Foo'
+                else:
+                    def __str__(self):
+                        return b'Foo'
+
+                    def __unicode__(self):
+                        return '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111'
+
+            self.assertEqual(smart_text(TestClass()),
+                             '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111')
+            self.assertEqual(smart_text(1), '1')
+            self.assertEqual(smart_text('foo'), 'foo')
+            self.assertEqual(smart_text(u), u)
+
+
+    class AdditionalParameterTestCase(unittest.TestCase):
+
+        def test_new_parameter_unicode_pair(self):
+            """  Check is unicode_pair parameter is working well. """
+
+

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -18,7 +18,7 @@ def test_slugify():
         eq_(slugify(x), y)
 
     def check_unicode_pairs(x, y):
-        eq_(slugify(x, unicode_pairs=unicode_pairs), y)
+        eq_(slugify(x, ok=u'-_~\xe9', unicode_pairs=unicode_pairs), y)
 
     s = [('xx x  - "#$@ x', 'xx-x-x'),
          (u'Bän...g (bang)', u'bäng-bang'),

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -17,7 +17,7 @@ def test_slugify():
     def check(x, y):
         eq_(slugify(x), y)
 
-    def check_unicode_pair(x, y):
+    def check_unicode_pairs(x, y):
         eq_(slugify(x, unicode_pairs=unicode_pairs), y)
 
     s = [('xx x  - "#$@ x', 'xx-x-x'),
@@ -46,7 +46,7 @@ def test_slugify():
         yield check, val, expected
 
     for val, expected in s_unicode_pair:
-        yield check_unicode_pair, val, expected
+        yield check_unicode_pairs, val, expected
 
 class SmartTextTestCase(unittest.TestCase):
 

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -40,8 +40,7 @@ def test_slugify():
          (u'¿x', u'x'),
         ]
 
-    s_unicode_pair = [(u'This is curreny Euro (\u20ac)', u'This is curreny Euro (E)'),
-                      (u'This is e with a trail: \xe9', u'This is e with a trail: e')]
+    s_unicode_pair = [(u'This is e with a trail: \xe9', u'this-is-e-with-a-trail-e')]
 
     for val, expected in s:
         yield check, val, expected

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -12,7 +12,7 @@ u = u'Ελληνικά'
 def test_slugify():
     x = '-'.join([u, u])
     y = ' - '.join([u, u])
-    unicode_pairs = {u'\u20ac': 'E', u'\xe9': 'e'}
+    unicode_pairs = {u'\u20ac': 'E', u'\xe9': 'e', u'\u0131': 'bla'}
 
     def check(x, y):
         eq_(slugify(x), y)
@@ -40,7 +40,8 @@ def test_slugify():
          (u'¿x', u'x'),
         ]
 
-    s_unicode_pair = [(u'This is e with a trail: \xe9', u'this-is-e-with-a-trail-e')]
+    s_unicode_pair = [(u'This is e with a trail: \xe9', u'this-is-e-with-a-trail-e'),
+                      (u'\u0131 this is i without a dot', u'bla-this-is-i-without-a-dot')]
 
     for val, expected in s:
         yield check, val, expected


### PR DESCRIPTION
## Example

     >>> slugify.sluggify(u'This is \xe9 test', unicode_pairs={u'\xe9', 'a'})
    u'this-is-a-test'
    instead of u'this-is-\xe9-test'