### PR TITLE
correction for using only_ascii with lower=True and/or spaces=False

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,44 @@
 
 Unicode Slugify is a slugifier that generates unicode slugs.  It was originally
 used in the Firefox Add-ons web site to generate slugs for add-ons and add-on
-collections.  Many of these add-ons and collections had unicode characters and
+collections. Many of these add-ons and collections had unicode characters and
 required more than simple transliteration.
 
 ## Usage
 
-    >>> import slugify
+```python
 
-    >>> slugify.slugify(u'Bän...g (bang)')
-    u'bäng-bang'
+from slugify import slugify, SLUG_OK
 
-    >>> slugify.slugify(u'Bäuma means a tree', only_ascii=True)
-    u'bauma-means-a-tree'
+# Default usage : lower, spaces replaced with "-", only alphanum and "-_~" chars, keeps unicode
+slugify(u'Bän...g (bang)')
+# u'bäng-bang'
 
-    >>> slugify(u'Bakıcı geldi', only_ascii=True)
-    u'bakici-geldi'
+# Keep capital letters and spaces
+slugify(u'Bän...g (bang)', lower=False, spaces=True)
+# u'Bäng bang'
+
+# Replace non ascii chars with their "best" representation
+slugify(u'北京 (capital of China)', only_ascii=True)
+# u'bei-jing-capital-of-china'
+
+# Allow some extra chars
+slugify(u'北京 (capital of China)', ok=SLUG_OK+'()', only_ascii=True)
+# u'bei-jing-(capital-of-china)'
+
+# "snake_case" exemple
+def snake_case(s):
+    # As "-" is not in allowed Chars, first one (`_`) is used for space remplacement
+    return slugify(s, ok='_', only_ascii=True)
+snake_case(u'北京 (capital of china)')
+# u'bei_jing_capital_of_china'
+
+# "CamelCase" exemple
+def camel_case(s):
+    return slugify(s.title(), ok='', only_ascii=True, lower=False)
+camel_case(u'北京 (capital of china)')
+# u'BeiJingCapitalOfChina'
+```
 
 ## Thanks
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,2 @@
 nose
+-r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 six
+unidecode

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -48,6 +48,13 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
 
     """
 
+    if only_ascii and type(ok) == unicode:
+        try:
+            ok.decode('ascii')
+        except UnicodeEncodeError:
+            raise ValueError((u'You can not use "only_ascii=True" with '
+                              u'a non ascii available chars in "ok" ("%s" given)') % ok)
+
     rv = []
     for c in unicodedata.normalize('NFKC', smart_text(s)):
         cat = unicodedata.category(c)[0]

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -56,12 +56,12 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
         if cat == 'Z':  # space
             rv.append(' ')
     new = ''.join(rv).strip()
+
+    if only_ascii:
+        new = unidecode(new)
     if not spaces:
         new = re.sub('[-\s]+', '-', new)
-
-    new = new.lower() if lower else new
-
-    if only_ascii == True:
-        new = unidecode(new)
+    if lower:
+        new = new.lower()
 
     return new

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -27,7 +27,7 @@ def smart_text(s, encoding='utf-8', errors='strict'):
 SLUG_OK = '-_~'
 
 
-def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
+def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False, space_replacement='-'):
     """
     Creates a unicode slug for given string with several options.
 
@@ -36,14 +36,20 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
 
     :param s: Your unicode string.
     :param ok: Extra characters outside of alphanumerics to be allowed.
-    :param lower: Lower the output string.
-    :param spaces: True allows spaces, False replaces a space with a dash (-).
-    :param only_ascii: True to replace non-ASCII unicode characters with their ASCII representations.
+               Default is '-_~'
+    :param lower: Lower the output string. 
+                  Default is True
+    :param spaces: True allows spaces, False replaces a space with the "space_replacement" param
+    :param only_ascii: True to replace non-ASCII unicode characters with 
+                       their ASCII representations.
+    :param space_replacement: Char used to replace spaces if "spaces" is False. 
+                              Default is dash ("-") or first char in ok if dash not allowed
     :type s: String
     :type ok: String
     :type lower: Bool
     :type spaces: Bool
     :type only_ascii: Bool
+    :type space_replacement: String
     :return: Slugified unicode string
 
     """
@@ -60,14 +66,16 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
         cat = unicodedata.category(c)[0]
         if cat in 'LN' or c in ok:
             rv.append(c)
-        if cat == 'Z':  # space
+        elif cat == 'Z':  # space
             rv.append(' ')
     new = ''.join(rv).strip()
 
     if only_ascii:
         new = unidecode(new)
     if not spaces:
-        new = re.sub('[-\s]+', ('-' if '-' in ok else ''), new)
+        if space_replacement and space_replacement not in ok:
+            space_replacement = ok[0] if ok else ''
+        new = re.sub('[%s\s]+' % space_replacement, space_replacement, new)
     if lower:
         new = new.lower()
 

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -67,7 +67,7 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
     if only_ascii:
         new = unidecode(new)
     if not spaces:
-        new = re.sub('[-\s]+', '-', new)
+        new = re.sub('[-\s]+', ('-' if '-' in ok else ''), new)
     if lower:
         new = new.lower()
 

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -31,6 +31,9 @@ def test_slugify():
     def check_ok_chars(x, y):
         eq_(slugify(x, ok=u'-♰é_è'), y)
 
+    def check_empty_ok_chars(x, y):
+        eq_(slugify(x, ok=''), y)
+
     def check_limited_ok_chars_only_ascii(x, y):
         eq_(slugify(x, ok='-', only_ascii=True), y)
 
@@ -71,6 +74,11 @@ def test_slugify():
                 (u'   ☂   Umbrella   Corp.   ☢   ', u'umbrella-corp'),
                 (u'~   breaking   space   ~', u'breaking-space'),]
 
+    empty_ok_chars = [(u'-♰no th ing ☢~', u'nothing'),
+                (u'♰ Vlad ♰ Țepeș ♰', u'vladțepeș'),# "ț" and "ș" are not "t" and "s"
+                (u'   ☂   Umbrella   Corp.   ☢   ', u'umbrellacorp'),
+                (u'~   breaking   space   ~', u'breakingspace'),]
+
     limited_ok_chars_only_ascii = [(u'♰é_è ☢~', u'ee'),
                 (u'♰ Vlad ♰ Țepeș ♰', u'vlad-tepes'), #♰ allowed but "Ț" => "t", "ș" => "s"
                 (u'   ☂   Umbrella   Corp.   ☢   ', u'umbrella-corp'),
@@ -90,6 +98,9 @@ def test_slugify():
 
     for val, expected in ok_chars:
         yield check_ok_chars, val, expected
+
+    for val, expected in empty_ok_chars:
+        yield check_empty_ok_chars, val, expected
 
     for val, expected in limited_ok_chars_only_ascii:
         yield check_limited_ok_chars_only_ascii, val, expected

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -105,6 +105,14 @@ def test_slugify():
     for val, expected in limited_ok_chars_only_ascii:
         yield check_limited_ok_chars_only_ascii, val, expected
 
+    #Test custom space replacement
+    x, y = (u'-☀- pretty waves under the sunset 😎', u'--~pretty~waves~under~the~sunset')
+    eq_(slugify(x, space_replacement='~'), y)
+
+    #Test default auto space replacement
+    x, y = (u'-☀- pretty waves under the sunset 😎', u'pretty~waves~under~the~sunset')
+    eq_(slugify(x, ok='~'), y)
+
 
 class SmartTextTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Because unidecode can add Caps and/or spaces, it must be called __before__ space striping and lowering. e.g:

```python
slugify(u'北京 (China)', only_ascii=True)
# before this correction:
'Bei Jing -china'
# with this correction:
'bei-jing-china'