### PR TITLE
python 3.x compat + tox and travis support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pip-log.txt
 dist
 *.egg-info
 .noseids
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+
+install: "pip install -r dev-requirements.txt"
+
+script: nosetests

--- a/README.md
+++ b/README.md
@@ -2,21 +2,44 @@
 
 Unicode Slugify is a slugifier that generates unicode slugs.  It was originally
 used in the Firefox Add-ons web site to generate slugs for add-ons and add-on
-collections.  Many of these add-ons and collections had unicode characters and
+collections. Many of these add-ons and collections had unicode characters and
 required more than simple transliteration.
 
 ## Usage
 
-    >>> import slugify
+```python
 
-    >>> slugify.slugify(u'Bän...g (bang)')
-    u'bäng-bang'
+from slugify import slugify, SLUG_OK
 
-    >>> slugify.slugify(u'Bäuma means a tree', only_ascii=True)
-    u'bauma-means-a-tree'
+# Default usage : lower, spaces replaced with "-", only alphanum and "-_~" chars, keeps unicode
+slugify(u'Bän...g (bang)')
+# u'bäng-bang'
 
-    >>> slugify(u'Bakıcı geldi', only_ascii=True)
-    u'bakici-geldi'
+# Keep capital letters and spaces
+slugify(u'Bän...g (bang)', lower=False, spaces=True)
+# u'Bäng bang'
+
+# Replace non ascii chars with their "best" representation
+slugify(u'北京 (capital of China)', only_ascii=True)
+# u'bei-jing-capital-of-china'
+
+# Allow some extra chars
+slugify(u'北京 (capital of China)', ok=SLUG_OK+'()', only_ascii=True)
+# u'bei-jing-(capital-of-china)'
+
+# "snake_case" exemple
+def snake_case(s):
+    # As "-" is not in allowed Chars, first one (`_`) is used for space remplacement
+    return slugify(s, ok='_', only_ascii=True)
+snake_case(u'北京 (capital of china)')
+# u'bei_jing_capital_of_china'
+
+# "CamelCase" exemple
+def camel_case(s):
+    return slugify(s.title(), ok='', only_ascii=True, lower=False)
+camel_case(u'北京 (capital of china)')
+# u'BeiJingCapitalOfChina'
+```
 
 ## Thanks
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,2 @@
 nose
+-r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 six
+unidecode

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8
+from __future__ import unicode_literals
+
 import re
 import six
 import unicodedata
@@ -54,12 +57,12 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False, space_rep
 
     """
 
-    if only_ascii and type(ok) == unicode:
+    if only_ascii and ok != SLUG_OK and hasattr(ok, 'decode'):
         try:
             ok.decode('ascii')
         except UnicodeEncodeError:
-            raise ValueError((u'You can not use "only_ascii=True" with '
-                              u'a non ascii available chars in "ok" ("%s" given)') % ok)
+            raise ValueError(('You can not use "only_ascii=True" with '
+                              'a non ascii available chars in "ok" ("%s" given)') % ok)
 
     rv = []
     for c in unicodedata.normalize('NFKC', smart_text(s)):

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -48,6 +48,13 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
 
     """
 
+    if only_ascii and type(ok) == unicode:
+        try:
+            ok.decode('ascii')
+        except UnicodeEncodeError:
+            raise ValueError((u'You can not use "only_ascii=True" with '
+                              u'a non ascii available chars in "ok" ("%s" given)') % ok)
+
     rv = []
     for c in unicodedata.normalize('NFKC', smart_text(s)):
         cat = unicodedata.category(c)[0]

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -56,12 +56,12 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
         if cat == 'Z':  # space
             rv.append(' ')
     new = ''.join(rv).strip()
+
+    if only_ascii:
+        new = unidecode(new)
     if not spaces:
         new = re.sub('[-\s]+', '-', new)
-
-    new = new.lower() if lower else new
-
-    if only_ascii == True:
-        new = unidecode(new)
+    if lower:
+        new = new.lower()
 
     return new

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -27,7 +27,7 @@ def smart_text(s, encoding='utf-8', errors='strict'):
 SLUG_OK = '-_~'
 
 
-def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
+def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False, space_replacement='-'):
     """
     Creates a unicode slug for given string with several options.
 
@@ -36,14 +36,20 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
 
     :param s: Your unicode string.
     :param ok: Extra characters outside of alphanumerics to be allowed.
-    :param lower: Lower the output string.
-    :param spaces: True allows spaces, False replaces a space with a dash (-).
-    :param only_ascii: True to replace non-ASCII unicode characters with their ASCII representations.
+               Default is '-_~'
+    :param lower: Lower the output string. 
+                  Default is True
+    :param spaces: True allows spaces, False replaces a space with the "space_replacement" param
+    :param only_ascii: True to replace non-ASCII unicode characters with 
+                       their ASCII representations.
+    :param space_replacement: Char used to replace spaces if "spaces" is False. 
+                              Default is dash ("-") or first char in ok if dash not allowed
     :type s: String
     :type ok: String
     :type lower: Bool
     :type spaces: Bool
     :type only_ascii: Bool
+    :type space_replacement: String
     :return: Slugified unicode string
 
     """
@@ -60,14 +66,16 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
         cat = unicodedata.category(c)[0]
         if cat in 'LN' or c in ok:
             rv.append(c)
-        if cat == 'Z':  # space
+        elif cat == 'Z':  # space
             rv.append(' ')
     new = ''.join(rv).strip()
 
     if only_ascii:
         new = unidecode(new)
     if not spaces:
-        new = re.sub('[-\s]+', ('-' if '-' in ok else ''), new)
+        if space_replacement and space_replacement not in ok:
+            space_replacement = ok[0] if ok else ''
+        new = re.sub('[%s\s]+' % space_replacement, space_replacement, new)
     if lower:
         new = new.lower()
 

--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -67,7 +67,7 @@ def slugify(s, ok=SLUG_OK, lower=True, spaces=False, only_ascii=False):
     if only_ascii:
         new = unidecode(new)
     if not spaces:
-        new = re.sub('[-\s]+', '-', new)
+        new = re.sub('[-\s]+', ('-' if '-' in ok else ''), new)
     if lower:
         new = new.lower()
 

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -31,6 +31,9 @@ def test_slugify():
     def check_ok_chars(x, y):
         eq_(slugify(x, ok=u'-♰é_è'), y)
 
+    def check_empty_ok_chars(x, y):
+        eq_(slugify(x, ok=''), y)
+
     def check_limited_ok_chars_only_ascii(x, y):
         eq_(slugify(x, ok='-', only_ascii=True), y)
 
@@ -71,6 +74,11 @@ def test_slugify():
                 (u'   ☂   Umbrella   Corp.   ☢   ', u'umbrella-corp'),
                 (u'~   breaking   space   ~', u'breaking-space'),]
 
+    empty_ok_chars = [(u'-♰no th ing ☢~', u'nothing'),
+                (u'♰ Vlad ♰ Țepeș ♰', u'vladțepeș'),# "ț" and "ș" are not "t" and "s"
+                (u'   ☂   Umbrella   Corp.   ☢   ', u'umbrellacorp'),
+                (u'~   breaking   space   ~', u'breakingspace'),]
+
     limited_ok_chars_only_ascii = [(u'♰é_è ☢~', u'ee'),
                 (u'♰ Vlad ♰ Țepeș ♰', u'vlad-tepes'), #♰ allowed but "Ț" => "t", "ș" => "s"
                 (u'   ☂   Umbrella   Corp.   ☢   ', u'umbrella-corp'),
@@ -90,6 +98,9 @@ def test_slugify():
 
     for val, expected in ok_chars:
         yield check_ok_chars, val, expected
+
+    for val, expected in empty_ok_chars:
+        yield check_empty_ok_chars, val, expected
 
     for val, expected in limited_ok_chars_only_ascii:
         yield check_limited_ok_chars_only_ascii, val, expected

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -105,6 +105,14 @@ def test_slugify():
     for val, expected in limited_ok_chars_only_ascii:
         yield check_limited_ok_chars_only_ascii, val, expected
 
+    #Test custom space replacement
+    x, y = (u'-☀- pretty waves under the sunset 😎', u'--~pretty~waves~under~the~sunset')
+    eq_(slugify(x, space_replacement='~'), y)
+
+    #Test default auto space replacement
+    x, y = (u'-☀- pretty waves under the sunset 😎', u'pretty~waves~under~the~sunset')
+    eq_(slugify(x, ok='~'), y)
+
 
 class SmartTextTestCase(unittest.TestCase):
 

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -1,11 +1,13 @@
-# -*- coding: utf-8 -*-
+# -*- coding: utf-8
+from __future__ import unicode_literals
+
 import six
 import unittest
 from nose.tools import eq_, raises
 
 from slugify import slugify, smart_text, SLUG_OK
 
-u = u'Ελληνικά'
+u = 'Ελληνικά'
 
 def test_slugify():
     x = '-'.join([u, u])
@@ -29,7 +31,7 @@ def test_slugify():
         eq_(slugify(x, lower=True, spaces=False, only_ascii=True), y)
 
     def check_ok_chars(x, y):
-        eq_(slugify(x, ok=u'-♰é_è'), y)
+        eq_(slugify(x, ok='-♰é_è'), y)
 
     def check_empty_ok_chars(x, y):
         eq_(slugify(x, ok=''), y)
@@ -38,7 +40,7 @@ def test_slugify():
         eq_(slugify(x, ok='-', only_ascii=True), y)
 
     s = [('xx x  - "#$@ x', 'xx-x-x'),
-         (u'Bän...g (bang)', u'bäng-bang'),
+         ('Bän...g (bang)', 'bäng-bang'),
          (u, u.lower()),
          (x, x.lower()),
          (y, x.lower()),
@@ -46,43 +48,43 @@ def test_slugify():
          ('tags/', 'tags'),
          ('holy_wars', 'holy_wars'),
          # Make sure we get a consistent result with decomposed chars:
-         (u'el ni\N{LATIN SMALL LETTER N WITH TILDE}o', u'el-ni\xf1o'),
-         (u'el nin\N{COMBINING TILDE}o', u'el-ni\xf1o'),
+         ('el ni\N{LATIN SMALL LETTER N WITH TILDE}o', 'el-ni\xf1o'),
+         ('el nin\N{COMBINING TILDE}o', 'el-ni\xf1o'),
          # Ensure we normalize appearance-only glyphs into their compatibility
          # forms:
-         (u'\N{LATIN SMALL LIGATURE FI}lms', u'films'),
+         ('\N{LATIN SMALL LIGATURE FI}lms', 'films'),
          # I don't really care what slugify returns.  Just don't crash.
-         (u'x𘍿', u'x'),
-         (u'ϧ΃𘒬𘓣',  u'\u03e7'),
-         (u'¿x', u'x'),
-         (u'Bakıcı geldi', u'bak\u0131c\u0131-geldi'),
-         (u'Bäuma means tree', u'b\xe4uma-means-tree')]
+         ('x𘍿', 'x'),
+         ('ϧ΃𘒬𘓣',  '\u03e7'),
+         ('¿x', 'x'),
+         ('Bakıcı geldi', 'bak\u0131c\u0131-geldi'),
+         ('Bäuma means tree', 'b\xe4uma-means-tree')]
 
-    only_ascii = [(u'Bakıcı geldi', u'bakici-geldi'), (u'Bäuma means tree', u'bauma-means-tree')]
+    only_ascii = [('Bakıcı geldi', 'bakici-geldi'), ('Bäuma means tree', 'bauma-means-tree')]
 
-    only_ascii_capital = [(u'BÄUMA MEANS TREE', u'BAUMA-MEANS-TREE'),
-                          (u'EMİN WAS HERE', u'EMIN-WAS-HERE')]
+    only_ascii_capital = [('BÄUMA MEANS TREE', 'BAUMA-MEANS-TREE'),
+                          ('EMİN WAS HERE', 'EMIN-WAS-HERE')]
 
-    only_ascii_lower_nospaces = [(u'北京 (China)', u'bei-jing-china'),
-                                 (u'   Москва (Russia)   ', u'moskva-russia'),
-                                 (u'♰ Vlad ♰ Țepeș ♰', u'vlad-tepes'),
-                                 (u'   ☂   Umbrella   Corp.   ☢   ', u'umbrella-corp'),
-                                 (u'~   breaking   space   ~', u'~-breaking-space-~'),]
+    only_ascii_lower_nospaces = [('北京 (China)', 'bei-jing-china'),
+                                 ('   Москва (Russia)   ', 'moskva-russia'),
+                                 ('♰ Vlad ♰ Țepeș ♰', 'vlad-tepes'),
+                                 ('   ☂   Umbrella   Corp.   ☢   ', 'umbrella-corp'),
+                                 ('~   breaking   space   ~', '~-breaking-space-~'),]
 
-    ok_chars = [(u'-♰é_è ok but not ☢~', u'-♰é_è-ok-but-not'),
-                (u'♰ Vlad ♰ Țepeș ♰', u'♰-vlad-♰-țepeș-♰'),# "ț" and "ș" are not "t" and "s"
-                (u'   ☂   Umbrella   Corp.   ☢   ', u'umbrella-corp'),
-                (u'~   breaking   space   ~', u'breaking-space'),]
+    ok_chars = [('-♰é_è ok but not ☢~', '-♰é_è-ok-but-not'),
+                ('♰ Vlad ♰ Țepeș ♰', '♰-vlad-♰-țepeș-♰'),# "ț" and "ș" are not "t" and "s"
+                ('   ☂   Umbrella   Corp.   ☢   ', 'umbrella-corp'),
+                ('~   breaking   space   ~', 'breaking-space'),]
 
-    empty_ok_chars = [(u'-♰no th ing ☢~', u'nothing'),
-                (u'♰ Vlad ♰ Țepeș ♰', u'vladțepeș'),# "ț" and "ș" are not "t" and "s"
-                (u'   ☂   Umbrella   Corp.   ☢   ', u'umbrellacorp'),
-                (u'~   breaking   space   ~', u'breakingspace'),]
+    empty_ok_chars = [('-♰no th ing ☢~', 'nothing'),
+                ('♰ Vlad ♰ Țepeș ♰', 'vladțepeș'),# "ț" and "ș" are not "t" and "s"
+                ('   ☂   Umbrella   Corp.   ☢   ', 'umbrellacorp'),
+                ('~   breaking   space   ~', 'breakingspace'),]
 
-    limited_ok_chars_only_ascii = [(u'♰é_è ☢~', u'ee'),
-                (u'♰ Vlad ♰ Țepeș ♰', u'vlad-tepes'), #♰ allowed but "Ț" => "t", "ș" => "s"
-                (u'   ☂   Umbrella   Corp.   ☢   ', u'umbrella-corp'),
-                (u'~   breaking   space   ~', u'breaking-space'),]
+    limited_ok_chars_only_ascii = [('♰é_è ☢~', 'ee'),
+                ('♰ Vlad ♰ Țepeș ♰', 'vlad-tepes'), #♰ allowed but "Ț" => "t", "ș" => "s"
+                ('   ☂   Umbrella   Corp.   ☢   ', 'umbrella-corp'),
+                ('~   breaking   space   ~', 'breaking-space'),]
 
     for val, expected in s:
         yield check, val, expected
@@ -106,11 +108,11 @@ def test_slugify():
         yield check_limited_ok_chars_only_ascii, val, expected
 
     #Test custom space replacement
-    x, y = (u'-☀- pretty waves under the sunset 😎', u'--~pretty~waves~under~the~sunset')
+    x, y = ('-☀- pretty waves under the sunset 😎', '--~pretty~waves~under~the~sunset')
     eq_(slugify(x, space_replacement='~'), y)
 
     #Test default auto space replacement
-    x, y = (u'-☀- pretty waves under the sunset 😎', u'pretty~waves~under~the~sunset')
+    x, y = ('-☀- pretty waves under the sunset 😎', 'pretty~waves~under~the~sunset')
     eq_(slugify(x, ok='~'), y)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py2{6,7}, py3{2,3,4}
+
+[testenv]
+commands = nosetests
+basepython =
+    py26: python2.6
+    py27: python2.7
+    py32: python3.2
+    py33: python3.3
+    py34: python3.4
+deps = -rdev-requirements.txt


### PR DESCRIPTION
Based on #18
* Corrects it to be compatible with those python versions : `2.6`, `2.7`, `3.2`, `3.3`, `3.4`.
* Adds `tox.ini` file to be able to use automated tests via tox with those python versions.
* Adds `.travis.yml` file to be able to use automated tests via travis with those python versions.