### PR TITLE
Drop python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='unicode-slugify',
-    version='0.1.3',
+    version='0.1.4',
     description='A slug generator that turns strings into unicode slugs.',
     long_description=open('README.md').read(),
     author='Jeff Balogh, Dave Dash',

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py2{6,7}, py3{2,3,4}
+envlist = py27, py3{2,3,4}
 
 [testenv]
 commands = nosetests
 basepython =
-    py26: python2.6
     py27: python2.7
     py32: python3.2
     py33: python3.3


### PR DESCRIPTION
Fixes #24 

`unidecode` package no longer supports python 2.6.

A side effect of this is being able to do `io.open('README.md', encoding='utf-8').read()` in the `setup.py` file